### PR TITLE
Use Orbit MVI Shared ViewModel for iOS

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -2,9 +2,10 @@ use_frameworks!
 
 platform :ios, '12.4'
 
-install! 'cocoapods', :deterministic_uuids => false
+install! 'cocoapods', :deterministic_uuids => false, :disable_input_output_paths => true
 
 target 'KaMPKitiOS' do
     pod 'shared', :path => '../shared/'
+    pod 'sharedOrbitSwift', :path => '../shared'
     pod 'SwifterSwift/SwiftStdlib', '~> 5.2.0' # Standard Library Extensions
 end


### PR DESCRIPTION
### 💬 Description
Fixes https://github.com/whether-jacket/weather-app-2022-kmm/issues/7
- `main` branch already has:
  - Orbit [dependencies](https://github.com/whether-jacket/weather-app-2022-kmm/blob/main/shared/build.gradle.kts).
  - [SharedVM](https://github.com/whether-jacket/weather-app-2022-kmm/blob/main/shared/src/commonMain/kotlin/co/touchlab/kampkit/metaweather/viewmodel/SharedViewModel.kt) using Orbit.
- We weren't able to get it working on iOS side.
  - This PR updates `Pod` file to match [Orbit MVI Sample project](https://github.com/orbit-mvi/orbit-sample-posts-multiplatform/blob/main/iosApp/Podfile) in hopes to help.
  - In running `pod install` get: `No podspec found for "sharedOrbitSwift" in "../shared"`

### 🌉 Screenshot

### 👷‍♂️ Testing
- `./gradlew :app:build`
- `./gradlew :shared:build`
- `xcodebuild -workspace ios/KaMPKitiOS.xcworkspace -scheme KaMPKitiOS 
    -sdk iphoneos -configuration Debug build -destination name="iPhone 8"`
